### PR TITLE
feat: Add dark/light mode toggle with theme-aware game elements

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,20 +1,25 @@
 NeoPong is a basic browser based video game inspired by the classic game Pong. The player controls a "paddle" and attempts to score goals against their opponent by bouncing the ball off the paddle.
 
 Specifically it has the following features
-* Main menu where the player can provide a name and start the round
-* Start menu includes an input to set the winning score for the round
-* Single player mode where the player can play versus an AI
-* The map is a square containing two rectangular paddles and one square ball
-* The player's paddle is on the left side and can move in a linear direction up and down using the W and S keys
-* The AI's paddle is on the right side and has the same movement restrictions as the player's paddle, however the AI will control the paddle to try and hit the ball back
-* There is a score board on the bottom of the page that counts the number of goals for the player and their AI opponent
-* When a goal is scored, play a brief celebratory animation (e.g., flash, screen shake, and/or particle burst)
-* Before the ball spawns at the start of the round and after each goal, display a centered countdown animation: "3... 2... 1... START!"
-* The two paddles should have contrasting colors to clearly distinguish the player and the AI
-* After a goal is scored, both paddles reset to the middle before the countdown and next serve
-* The default winning score should be 3
-* The ball displays a short trailing animation whose color reflects the last hitter (player vs AI)
+
+- Main menu where the player can provide a name and start the round
+- Start menu includes an input to set the winning score for the round
+- Single player mode where the player can play versus an AI
+- The map is a square containing two rectangular paddles and one square ball
+- The player's paddle is on the left side and can move in a linear direction up and down using the W and S keys
+- The AI's paddle is on the right side and has the same movement restrictions as the player's paddle, however the AI will control the paddle to try and hit the ball back
+- There is a score board on the bottom of the page that counts the number of goals for the player and their AI opponent
+- When a goal is scored, play a brief celebratory animation (e.g., flash, screen shake, and/or particle burst)
+- Before the ball spawns at the start of the round and after each goal, display a centered countdown animation: "3... 2... 1... START!"
+- The two paddles should have contrasting colors to clearly distinguish the player and the AI
+- After a goal is scored, both paddles reset to the middle before the countdown and next serve
+- The default winning score should be 3
+- The ball displays a short trailing animation whose color reflects the last hitter (player vs AI)
+- Dark and light mode toggle button in the header that allows users to switch between color schemes
+- Theme preference is saved in localStorage and restored on page reload
+- All game elements (paddles, ball, net, borders, particles, text) adapt to the selected theme for optimal readability
 
 ## Implementation details
-* The game must be compatible with popular browsers including Google Chrome
-* You are free to use any free frameworks or programing languages to accomplish the task
+
+- The game must be compatible with popular browsers including Google Chrome
+- You are free to use any free frameworks or programing languages to accomplish the task

--- a/game.js
+++ b/game.js
@@ -1,403 +1,528 @@
 (() => {
-    const canvas = document.getElementById('gameCanvas');
-    const ctx = canvas.getContext('2d');
+  const canvas = document.getElementById("gameCanvas");
+  const ctx = canvas.getContext("2d");
 
-    // Square map size (720x720) already set via HTML
-    const FIELD_SIZE = canvas.width; // 720
+  // Square map size (720x720) already set via HTML
+  const FIELD_SIZE = canvas.width; // 720
 
-    // Gameplay constants
-    const PADDLE_WIDTH = 16;
-    const PADDLE_HEIGHT = 110;
-    const BALL_SIZE = 14; // square
-    const PLAYER_X = 24; // left paddle x
-    const AI_X = FIELD_SIZE - 24 - PADDLE_WIDTH; // right paddle x
+  // Gameplay constants
+  const PADDLE_WIDTH = 16;
+  const PADDLE_HEIGHT = 110;
+  const BALL_SIZE = 14; // square
+  const PLAYER_X = 24; // left paddle x
+  const AI_X = FIELD_SIZE - 24 - PADDLE_WIDTH; // right paddle x
 
-    const PADDLE_SPEED = 6.0; // px per frame
-    const BALL_START_SPEED = 5.0;
-    const BALL_MAX_SPEED = 14.0;
-    const BALL_SPEEDUP_ON_HIT = 1.05;
-    const TRAIL_MAX_POINTS = 18;
+  const PADDLE_SPEED = 6.0; // px per frame
+  const BALL_START_SPEED = 5.0;
+  const BALL_MAX_SPEED = 14.0;
+  const BALL_SPEEDUP_ON_HIT = 1.05;
+  const TRAIL_MAX_POINTS = 18;
 
-    // State
-    let playerName = 'Player';
-    let playerScore = 0;
-    let aiScore = 0;
+  // State
+  let playerName = "Player";
+  let playerScore = 0;
+  let aiScore = 0;
 
-    const player = { x: PLAYER_X, y: (FIELD_SIZE - PADDLE_HEIGHT) / 2, vy: 0 };
-    const ai = { x: AI_X, y: (FIELD_SIZE - PADDLE_HEIGHT) / 2, vy: 0 };
-    const ball = { x: FIELD_SIZE / 2, y: FIELD_SIZE / 2, vx: 0, vy: 0, speed: BALL_START_SPEED };
-    let lastHitBy = null; // 'player' | 'ai' | null
-    const trailPoints = [];
+  const player = { x: PLAYER_X, y: (FIELD_SIZE - PADDLE_HEIGHT) / 2, vy: 0 };
+  const ai = { x: AI_X, y: (FIELD_SIZE - PADDLE_HEIGHT) / 2, vy: 0 };
+  const ball = {
+    x: FIELD_SIZE / 2,
+    y: FIELD_SIZE / 2,
+    vx: 0,
+    vy: 0,
+    speed: BALL_START_SPEED,
+  };
+  let lastHitBy = null; // 'player' | 'ai' | null
+  const trailPoints = [];
 
-    // UI elements
-    const menu = document.getElementById('menu');
-    const menuSub = document.getElementById('menu-sub');
-    const startBtn = document.getElementById('startBtn');
-    const playerNameInput = document.getElementById('playerName');
-    const winningScoreInput = document.getElementById('winningScore');
-    const playerLabel = document.getElementById('playerLabel');
-    const aiLabel = document.getElementById('aiLabel');
-    const playerScoreEl = document.getElementById('playerScore');
-    const aiScoreEl = document.getElementById('aiScore');
-    const goalFlashEl = document.getElementById('goalFlash');
-    const countdownEl = document.getElementById('countdown');
-    const countdownTextEl = document.getElementById('countdownText');
+  // UI elements
+  const menu = document.getElementById("menu");
+  const menuSub = document.getElementById("menu-sub");
+  const startBtn = document.getElementById("startBtn");
+  const playerNameInput = document.getElementById("playerName");
+  const winningScoreInput = document.getElementById("winningScore");
+  const playerLabel = document.getElementById("playerLabel");
+  const aiLabel = document.getElementById("aiLabel");
+  const playerScoreEl = document.getElementById("playerScore");
+  const aiScoreEl = document.getElementById("aiScore");
+  const goalFlashEl = document.getElementById("goalFlash");
+  const countdownEl = document.getElementById("countdown");
+  const countdownTextEl = document.getElementById("countdownText");
 
-    // Input state
-    const keys = { w: false, s: false };
+  // Theme toggle elements
+  const themeToggle = document.getElementById("themeToggle");
+  const themeIcon = document.getElementById("themeIcon");
+  const themeText = document.getElementById("themeText");
 
-    function clamp(value, min, max) {
-        return Math.max(min, Math.min(max, value));
+  // Input state
+  const keys = { w: false, s: false };
+
+  function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  function resetBall(direction = Math.random() > 0.5 ? 1 : -1) {
+    ball.x = FIELD_SIZE / 2 - BALL_SIZE / 2;
+    ball.y = FIELD_SIZE / 2 - BALL_SIZE / 2;
+    ball.speed = BALL_START_SPEED;
+    const angle = Math.random() * 0.6 - 0.3; // -0.3..0.3 radians for mild vertical variation
+    ball.vx = Math.cos(angle) * ball.speed * direction;
+    ball.vy = Math.sin(angle) * ball.speed;
+  }
+
+  let targetScore = 3;
+  let isPlaying = false;
+  let showBall = false;
+
+  function showCountdown(done) {
+    if (!countdownEl || !countdownTextEl) {
+      done();
+      return;
     }
+    const steps = ["3", "2", "1", "START!"];
+    let idx = 0;
+    countdownEl.style.display = "grid";
+    countdownEl.setAttribute("aria-hidden", "false");
 
-    function resetBall(direction = Math.random() > 0.5 ? 1 : -1) {
-        ball.x = FIELD_SIZE / 2 - BALL_SIZE / 2;
-        ball.y = FIELD_SIZE / 2 - BALL_SIZE / 2;
-        ball.speed = BALL_START_SPEED;
-        const angle = (Math.random() * 0.6 - 0.3); // -0.3..0.3 radians for mild vertical variation
-        ball.vx = Math.cos(angle) * ball.speed * direction;
-        ball.vy = Math.sin(angle) * ball.speed;
-    }
+    const runStep = () => {
+      if (idx >= steps.length) {
+        countdownEl.style.display = "none";
+        countdownEl.setAttribute("aria-hidden", "true");
+        done();
+        return;
+      }
+      countdownTextEl.textContent = steps[idx++];
+      countdownTextEl.classList.add("show");
+      setTimeout(() => {
+        countdownTextEl.classList.remove("show");
+        setTimeout(runStep, 160);
+      }, 520);
+    };
+    runStep();
+  }
 
-    let targetScore = 3;
-    let isPlaying = false;
-    let showBall = false;
-
-    function showCountdown(done) {
-        if (!countdownEl || !countdownTextEl) {
-            done();
-            return;
-        }
-        const steps = ['3', '2', '1', 'START!'];
-        let idx = 0;
-        countdownEl.style.display = 'grid';
-        countdownEl.setAttribute('aria-hidden', 'false');
-
-        const runStep = () => {
-            if (idx >= steps.length) {
-                countdownEl.style.display = 'none';
-                countdownEl.setAttribute('aria-hidden', 'true');
-                done();
-                return;
-            }
-            countdownTextEl.textContent = steps[idx++];
-            countdownTextEl.classList.add('show');
-            setTimeout(() => {
-                countdownTextEl.classList.remove('show');
-                setTimeout(runStep, 160);
-            }, 520);
-        };
-        runStep();
-    }
-
-    function startRound(direction) {
-        isPlaying = false;
-        showBall = false;
-        // park ball in the center while waiting
-        ball.x = FIELD_SIZE / 2 - BALL_SIZE / 2;
-        ball.y = FIELD_SIZE / 2 - BALL_SIZE / 2;
-        ball.vx = 0; ball.vy = 0;
-        trailPoints.length = 0;
-        lastHitBy = null;
-        showCountdown(() => {
-            resetBall(direction);
-            showBall = true;
-            isPlaying = true;
-        });
-    }
-
-    function centerPaddles() {
-        player.y = (FIELD_SIZE - PADDLE_HEIGHT) / 2;
-        ai.y = (FIELD_SIZE - PADDLE_HEIGHT) / 2;
-    }
-
-    function startGame() {
-        const name = playerNameInput.value.trim();
-        playerName = name || 'Player';
-        const parsedTarget = parseInt((winningScoreInput && winningScoreInput.value) ? winningScoreInput.value : '3', 10);
-        targetScore = Number.isFinite(parsedTarget) ? clamp(parsedTarget, 1, 21) : 3;
-        if (winningScoreInput) winningScoreInput.value = String(targetScore);
-        playerLabel.textContent = playerName;
-        aiLabel.textContent = 'AI';
-        playerScore = 0; aiScore = 0;
-        updateScoreboard();
-        centerPaddles();
-        menu.style.display = 'none';
-        if (menuSub) menuSub.textContent = 'Enter your name and winning score, then press Start.';
-        startRound(Math.random() > 0.5 ? 1 : -1);
-    }
-
-    function updateScoreboard() {
-        playerScoreEl.textContent = String(playerScore);
-        aiScoreEl.textContent = String(aiScore);
-    }
-
-    // Input handlers
-    window.addEventListener('keydown', (e) => {
-        if (e.repeat) return;
-        if (e.key === 'w' || e.key === 'W') keys.w = true;
-        if (e.key === 's' || e.key === 'S') keys.s = true;
+  function startRound(direction) {
+    isPlaying = false;
+    showBall = false;
+    // park ball in the center while waiting
+    ball.x = FIELD_SIZE / 2 - BALL_SIZE / 2;
+    ball.y = FIELD_SIZE / 2 - BALL_SIZE / 2;
+    ball.vx = 0;
+    ball.vy = 0;
+    trailPoints.length = 0;
+    lastHitBy = null;
+    showCountdown(() => {
+      resetBall(direction);
+      showBall = true;
+      isPlaying = true;
     });
-    window.addEventListener('keyup', (e) => {
-        if (e.key === 'w' || e.key === 'W') keys.w = false;
-        if (e.key === 's' || e.key === 'S') keys.s = false;
-    });
+  }
 
-    startBtn.addEventListener('click', () => startGame());
-    playerNameInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') startGame();
+  function centerPaddles() {
+    player.y = (FIELD_SIZE - PADDLE_HEIGHT) / 2;
+    ai.y = (FIELD_SIZE - PADDLE_HEIGHT) / 2;
+  }
+
+  function startGame() {
+    const name = playerNameInput.value.trim();
+    playerName = name || "Player";
+    const parsedTarget = parseInt(
+      winningScoreInput && winningScoreInput.value
+        ? winningScoreInput.value
+        : "3",
+      10
+    );
+    targetScore = Number.isFinite(parsedTarget)
+      ? clamp(parsedTarget, 1, 21)
+      : 3;
+    if (winningScoreInput) winningScoreInput.value = String(targetScore);
+    playerLabel.textContent = playerName;
+    aiLabel.textContent = "AI";
+    playerScore = 0;
+    aiScore = 0;
+    updateScoreboard();
+    centerPaddles();
+    menu.style.display = "none";
+    if (menuSub)
+      menuSub.textContent =
+        "Enter your name and winning score, then press Start.";
+    startRound(Math.random() > 0.5 ? 1 : -1);
+  }
+
+  function updateScoreboard() {
+    playerScoreEl.textContent = String(playerScore);
+    aiScoreEl.textContent = String(aiScore);
+  }
+
+  // Input handlers
+  window.addEventListener("keydown", (e) => {
+    if (e.repeat) return;
+    if (e.key === "w" || e.key === "W") keys.w = true;
+    if (e.key === "s" || e.key === "S") keys.s = true;
+  });
+  window.addEventListener("keyup", (e) => {
+    if (e.key === "w" || e.key === "W") keys.w = false;
+    if (e.key === "s" || e.key === "S") keys.s = false;
+  });
+
+  startBtn.addEventListener("click", () => startGame());
+  playerNameInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") startGame();
+  });
+  if (winningScoreInput) {
+    winningScoreInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") startGame();
+    });
+  }
+
+  // AI logic: simple proportional controller toward ball y with reaction delay and max speed
+  function updateAI() {
+    const targetY = ball.y + BALL_SIZE / 2 - PADDLE_HEIGHT / 2;
+    const delta = targetY - ai.y;
+    const aiMax = PADDLE_SPEED * 0.95;
+    const step = clamp(delta * 0.12, -aiMax, aiMax);
+    ai.y += step;
+    ai.y = clamp(ai.y, 0, FIELD_SIZE - PADDLE_HEIGHT);
+  }
+
+  function updatePlayer() {
+    let vy = 0;
+    if (keys.w) vy -= PADDLE_SPEED;
+    if (keys.s) vy += PADDLE_SPEED;
+    player.y = clamp(player.y + vy, 0, FIELD_SIZE - PADDLE_HEIGHT);
+  }
+
+  function rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
+    return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+  }
+
+  // Trail helpers
+  function getTrailRgb() {
+    const isLightTheme =
+      document.documentElement.getAttribute("data-theme") === "light";
+    if (lastHitBy === "player") {
+      return isLightTheme ? [30, 41, 59] : [231, 238, 247]; // dark in light theme, light in dark theme
+    }
+    if (lastHitBy === "ai") return [41, 163, 255]; // blue (same in both themes)
+    return isLightTheme ? [0, 184, 148] : [0, 224, 184]; // slightly darker green in light theme
+  }
+
+  function updateTrail() {
+    if (showBall) {
+      trailPoints.push({ x: ball.x, y: ball.y });
+      if (trailPoints.length > TRAIL_MAX_POINTS) trailPoints.shift();
+    }
+  }
+
+  function drawTrail() {
+    if (trailPoints.length === 0) return;
+    const [r, g, b] = getTrailRgb();
+    for (let i = 0; i < trailPoints.length; i++) {
+      const p = trailPoints[i];
+      const t = (i + 1) / trailPoints.length;
+      const alpha = 0.05 + t * 0.35;
+      const size = BALL_SIZE * (0.65 + t * 0.35);
+      const offset = (BALL_SIZE - size) / 2;
+      ctx.fillStyle = `rgba(${r},${g},${b},${alpha})`;
+      ctx.fillRect(p.x + offset, p.y + offset, size, size);
+    }
+  }
+
+  // Particle effects for goal animation
+  const particles = [];
+  function spawnGoalParticles(x, y) {
+    const count = 36;
+    for (let i = 0; i < count; i++) {
+      const angle = (Math.PI * 2 * i) / count + Math.random() * 0.25;
+      const speed = 3 + Math.random() * 4;
+      particles.push({
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        life: 34 + Math.random() * 18,
+      });
+    }
+  }
+
+  function updateParticles() {
+    for (let i = particles.length - 1; i >= 0; i--) {
+      const p = particles[i];
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vx *= 0.98;
+      p.vy *= 0.98;
+      p.life -= 1;
+      if (p.life <= 0) particles.splice(i, 1);
+    }
+  }
+
+  function drawParticles() {
+    const isLightTheme =
+      document.documentElement.getAttribute("data-theme") === "light";
+    for (const p of particles) {
+      const alpha = Math.max(0, Math.min(1, p.life / 40));
+      const color = isLightTheme ? [0, 184, 148] : [0, 224, 184]; // slightly darker green in light theme
+      ctx.fillStyle = `rgba(${color[0]},${color[1]},${color[2]},${alpha})`;
+      ctx.fillRect(p.x, p.y, 3, 3);
+    }
+  }
+
+  function triggerGoalFX(scoredByPlayer) {
+    if (goalFlashEl) {
+      goalFlashEl.style.opacity = "1";
+      setTimeout(() => {
+        goalFlashEl.style.opacity = "0";
+      }, 200);
+    }
+    const stage = document.querySelector(".stage-wrapper");
+    if (stage) {
+      stage.classList.remove("shake");
+      // reflow to restart animation
+      void stage.offsetHeight;
+      stage.classList.add("shake");
+    }
+    const x = scoredByPlayer ? FIELD_SIZE - 40 : 40;
+    const y = FIELD_SIZE / 2;
+    spawnGoalParticles(x, y);
+  }
+
+  function maybeEndRound() {
+    if (playerScore >= targetScore || aiScore >= targetScore) {
+      const winner = playerScore >= targetScore ? playerName : "AI";
+      if (menuSub)
+        menuSub.textContent = `${winner} wins! Enter details to play again.`;
+      menu.style.display = "grid";
+      isPlaying = false;
+      return true;
+    }
+    return false;
+  }
+
+  function updateBall() {
+    ball.x += ball.vx;
+    ball.y += ball.vy;
+
+    // Top/bottom collisions
+    if (ball.y <= 0) {
+      ball.y = 0;
+      ball.vy *= -1;
+    } else if (ball.y + BALL_SIZE >= FIELD_SIZE) {
+      ball.y = FIELD_SIZE - BALL_SIZE;
+      ball.vy *= -1;
+    }
+
+    // Paddle collisions
+    if (
+      rectsOverlap(
+        ball.x,
+        ball.y,
+        BALL_SIZE,
+        BALL_SIZE,
+        player.x,
+        player.y,
+        PADDLE_WIDTH,
+        PADDLE_HEIGHT
+      )
+    ) {
+      ball.x = player.x + PADDLE_WIDTH; // avoid sticking
+      const hitPos = ball.y + BALL_SIZE / 2 - (player.y + PADDLE_HEIGHT / 2);
+      const norm = hitPos / (PADDLE_HEIGHT / 2);
+      const angle = norm * 0.75; // max ~43 degrees
+      const speed = clamp(
+        Math.hypot(ball.vx, ball.vy) * BALL_SPEEDUP_ON_HIT,
+        BALL_START_SPEED,
+        BALL_MAX_SPEED
+      );
+      ball.vx = Math.cos(angle) * speed;
+      ball.vy = Math.sin(angle) * speed;
+      lastHitBy = "player";
+    } else if (
+      rectsOverlap(
+        ball.x,
+        ball.y,
+        BALL_SIZE,
+        BALL_SIZE,
+        ai.x,
+        ai.y,
+        PADDLE_WIDTH,
+        PADDLE_HEIGHT
+      )
+    ) {
+      ball.x = ai.x - BALL_SIZE;
+      const hitPos = ball.y + BALL_SIZE / 2 - (ai.y + PADDLE_HEIGHT / 2);
+      const norm = hitPos / (PADDLE_HEIGHT / 2);
+      const angle = norm * 0.75;
+      const speed = clamp(
+        Math.hypot(ball.vx, ball.vy) * BALL_SPEEDUP_ON_HIT,
+        BALL_START_SPEED,
+        BALL_MAX_SPEED
+      );
+      ball.vx = -Math.cos(angle) * speed;
+      ball.vy = Math.sin(angle) * speed;
+      lastHitBy = "ai";
+    }
+
+    // Goals
+    if (ball.x + BALL_SIZE < 0) {
+      aiScore += 1;
+      updateScoreboard();
+      centerPaddles();
+      triggerGoalFX(false);
+      if (!maybeEndRound()) startRound(1);
+    } else if (ball.x > FIELD_SIZE) {
+      playerScore += 1;
+      updateScoreboard();
+      centerPaddles();
+      triggerGoalFX(true);
+      if (!maybeEndRound()) startRound(-1);
+    }
+  }
+
+  function drawNet() {
+    ctx.save();
+    const isLightTheme =
+      document.documentElement.getAttribute("data-theme") === "light";
+    ctx.strokeStyle = isLightTheme
+      ? "rgba(0,0,0,0.15)"
+      : "rgba(255,255,255,0.1)";
+    ctx.lineWidth = 2;
+    ctx.setLineDash([8, 12]);
+    ctx.beginPath();
+    ctx.moveTo(FIELD_SIZE / 2, 0);
+    ctx.lineTo(FIELD_SIZE / 2, FIELD_SIZE);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, FIELD_SIZE, FIELD_SIZE);
+
+    const isLightTheme =
+      document.documentElement.getAttribute("data-theme") === "light";
+
+    // field border glow
+    ctx.save();
+    ctx.shadowBlur = 24;
+    ctx.shadowColor = isLightTheme
+      ? "rgba(0,224,184,0.15)"
+      : "rgba(0,224,184,0.25)";
+    ctx.strokeStyle = isLightTheme
+      ? "rgba(0,0,0,0.1)"
+      : "rgba(255,255,255,0.08)";
+    ctx.lineWidth = 2;
+    ctx.strokeRect(1, 1, FIELD_SIZE - 2, FIELD_SIZE - 2);
+    ctx.restore();
+
+    drawNet();
+
+    // paddles with contrasting colors
+    ctx.fillStyle = isLightTheme ? "#1e293b" : "#e7eef7"; // player: dark in light theme, light in dark theme
+    ctx.fillRect(player.x, player.y, PADDLE_WIDTH, PADDLE_HEIGHT);
+    ctx.fillStyle = "#29a3ff"; // AI: blue (same in both themes)
+    ctx.fillRect(ai.x, ai.y, PADDLE_WIDTH, PADDLE_HEIGHT);
+
+    // trail and ball
+    drawTrail();
+    if (showBall) {
+      ctx.fillStyle = isLightTheme ? "#00b894" : "#00e0b8"; // slightly darker green in light theme
+      ctx.fillRect(ball.x, ball.y, BALL_SIZE, BALL_SIZE);
+    }
+    // particles on top
+    drawParticles();
+  }
+
+  function update() {
+    if (isPlaying) {
+      updatePlayer();
+      updateAI();
+      updateBall();
+    }
+    updateParticles();
+    updateTrail();
+  }
+
+  function loop() {
+    update();
+    draw();
+    requestAnimationFrame(loop);
+  }
+
+  // Theme management
+  function initTheme() {
+    // Load saved theme from localStorage
+    try {
+      const savedTheme = localStorage.getItem("neopong:theme");
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        themeIcon.innerHTML =
+          '<circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>';
+        themeText.textContent = "Light";
+      }
+    } catch (_) {}
+  }
+
+  function toggleTheme() {
+    const currentTheme = document.documentElement.getAttribute("data-theme");
+    const newTheme = currentTheme === "light" ? "dark" : "light";
+
+    document.documentElement.setAttribute("data-theme", newTheme);
+
+    if (newTheme === "light") {
+      themeIcon.innerHTML =
+        '<circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>';
+      themeText.textContent = "Light";
+    } else {
+      themeIcon.innerHTML =
+        '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>';
+      themeText.textContent = "Dark";
+    }
+
+    // Save theme preference
+    try {
+      localStorage.setItem("neopong:theme", newTheme);
+    } catch (_) {}
+  }
+
+  // Initialize
+  function init() {
+    // Initialize theme
+    initTheme();
+
+    // Pre-fill player name from localStorage
+    try {
+      const saved = localStorage.getItem("neopong:playerName");
+      if (saved) playerNameInput.value = saved;
+      const savedTarget = localStorage.getItem("neopong:targetScore");
+      if (savedTarget && winningScoreInput)
+        winningScoreInput.value = savedTarget;
+    } catch (_) {}
+
+    // Persist name and winning score when changed
+    playerNameInput.addEventListener("change", () => {
+      try {
+        localStorage.setItem(
+          "neopong:playerName",
+          playerNameInput.value.trim()
+        );
+      } catch (_) {}
     });
     if (winningScoreInput) {
-        winningScoreInput.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') startGame();
-        });
-    }
-
-    // AI logic: simple proportional controller toward ball y with reaction delay and max speed
-    function updateAI() {
-        const targetY = ball.y + BALL_SIZE / 2 - PADDLE_HEIGHT / 2;
-        const delta = targetY - ai.y;
-        const aiMax = PADDLE_SPEED * 0.95;
-        const step = clamp(delta * 0.12, -aiMax, aiMax);
-        ai.y += step;
-        ai.y = clamp(ai.y, 0, FIELD_SIZE - PADDLE_HEIGHT);
-    }
-
-    function updatePlayer() {
-        let vy = 0;
-        if (keys.w) vy -= PADDLE_SPEED;
-        if (keys.s) vy += PADDLE_SPEED;
-        player.y = clamp(player.y + vy, 0, FIELD_SIZE - PADDLE_HEIGHT);
-    }
-
-    function rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
-        return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
-    }
-
-    // Trail helpers
-    function getTrailRgb() {
-        if (lastHitBy === 'player') return [231, 238, 247];
-        if (lastHitBy === 'ai') return [41, 163, 255];
-        return [0, 224, 184];
-    }
-
-    function updateTrail() {
-        if (showBall) {
-            trailPoints.push({ x: ball.x, y: ball.y });
-            if (trailPoints.length > TRAIL_MAX_POINTS) trailPoints.shift();
-        }
-    }
-
-    function drawTrail() {
-        if (trailPoints.length === 0) return;
-        const [r, g, b] = getTrailRgb();
-        for (let i = 0; i < trailPoints.length; i++) {
-            const p = trailPoints[i];
-            const t = (i + 1) / trailPoints.length;
-            const alpha = 0.05 + t * 0.35;
-            const size = BALL_SIZE * (0.65 + t * 0.35);
-            const offset = (BALL_SIZE - size) / 2;
-            ctx.fillStyle = `rgba(${r},${g},${b},${alpha})`;
-            ctx.fillRect(p.x + offset, p.y + offset, size, size);
-        }
-    }
-
-    // Particle effects for goal animation
-    const particles = [];
-    function spawnGoalParticles(x, y) {
-        const count = 36;
-        for (let i = 0; i < count; i++) {
-            const angle = (Math.PI * 2 * i) / count + Math.random() * 0.25;
-            const speed = 3 + Math.random() * 4;
-            particles.push({
-                x, y,
-                vx: Math.cos(angle) * speed,
-                vy: Math.sin(angle) * speed,
-                life: 34 + Math.random() * 18,
-            });
-        }
-    }
-
-    function updateParticles() {
-        for (let i = particles.length - 1; i >= 0; i--) {
-            const p = particles[i];
-            p.x += p.vx;
-            p.y += p.vy;
-            p.vx *= 0.98;
-            p.vy *= 0.98;
-            p.life -= 1;
-            if (p.life <= 0) particles.splice(i, 1);
-        }
-    }
-
-    function drawParticles() {
-        for (const p of particles) {
-            const alpha = Math.max(0, Math.min(1, p.life / 40));
-            ctx.fillStyle = `rgba(0,224,184,${alpha})`;
-            ctx.fillRect(p.x, p.y, 3, 3);
-        }
-    }
-
-    function triggerGoalFX(scoredByPlayer) {
-        if (goalFlashEl) {
-            goalFlashEl.style.opacity = '1';
-            setTimeout(() => { goalFlashEl.style.opacity = '0'; }, 200);
-        }
-        const stage = document.querySelector('.stage-wrapper');
-        if (stage) {
-            stage.classList.remove('shake');
-            // reflow to restart animation
-            void stage.offsetHeight;
-            stage.classList.add('shake');
-        }
-        const x = scoredByPlayer ? FIELD_SIZE - 40 : 40;
-        const y = FIELD_SIZE / 2;
-        spawnGoalParticles(x, y);
-    }
-
-    function maybeEndRound() {
-        if (playerScore >= targetScore || aiScore >= targetScore) {
-            const winner = playerScore >= targetScore ? playerName : 'AI';
-            if (menuSub) menuSub.textContent = `${winner} wins! Enter details to play again.`;
-            menu.style.display = 'grid';
-            isPlaying = false;
-            return true;
-        }
-        return false;
-    }
-
-    function updateBall() {
-        ball.x += ball.vx;
-        ball.y += ball.vy;
-
-        // Top/bottom collisions
-        if (ball.y <= 0) {
-            ball.y = 0;
-            ball.vy *= -1;
-        } else if (ball.y + BALL_SIZE >= FIELD_SIZE) {
-            ball.y = FIELD_SIZE - BALL_SIZE;
-            ball.vy *= -1;
-        }
-
-        // Paddle collisions
-        if (rectsOverlap(ball.x, ball.y, BALL_SIZE, BALL_SIZE, player.x, player.y, PADDLE_WIDTH, PADDLE_HEIGHT)) {
-            ball.x = player.x + PADDLE_WIDTH; // avoid sticking
-            const hitPos = (ball.y + BALL_SIZE / 2) - (player.y + PADDLE_HEIGHT / 2);
-            const norm = hitPos / (PADDLE_HEIGHT / 2);
-            const angle = norm * 0.75; // max ~43 degrees
-            const speed = clamp(Math.hypot(ball.vx, ball.vy) * BALL_SPEEDUP_ON_HIT, BALL_START_SPEED, BALL_MAX_SPEED);
-            ball.vx = Math.cos(angle) * speed;
-            ball.vy = Math.sin(angle) * speed;
-            lastHitBy = 'player';
-        } else if (rectsOverlap(ball.x, ball.y, BALL_SIZE, BALL_SIZE, ai.x, ai.y, PADDLE_WIDTH, PADDLE_HEIGHT)) {
-            ball.x = ai.x - BALL_SIZE;
-            const hitPos = (ball.y + BALL_SIZE / 2) - (ai.y + PADDLE_HEIGHT / 2);
-            const norm = hitPos / (PADDLE_HEIGHT / 2);
-            const angle = norm * 0.75;
-            const speed = clamp(Math.hypot(ball.vx, ball.vy) * BALL_SPEEDUP_ON_HIT, BALL_START_SPEED, BALL_MAX_SPEED);
-            ball.vx = -Math.cos(angle) * speed;
-            ball.vy = Math.sin(angle) * speed;
-            lastHitBy = 'ai';
-        }
-
-        // Goals
-        if (ball.x + BALL_SIZE < 0) {
-            aiScore += 1;
-            updateScoreboard();
-            centerPaddles();
-            triggerGoalFX(false);
-            if (!maybeEndRound()) startRound(1);
-        } else if (ball.x > FIELD_SIZE) {
-            playerScore += 1;
-            updateScoreboard();
-            centerPaddles();
-            triggerGoalFX(true);
-            if (!maybeEndRound()) startRound(-1);
-        }
-    }
-
-    function drawNet() {
-        ctx.save();
-        ctx.strokeStyle = 'rgba(255,255,255,0.1)';
-        ctx.lineWidth = 2;
-        ctx.setLineDash([8, 12]);
-        ctx.beginPath();
-        ctx.moveTo(FIELD_SIZE / 2, 0);
-        ctx.lineTo(FIELD_SIZE / 2, FIELD_SIZE);
-        ctx.stroke();
-        ctx.restore();
-    }
-
-    function draw() {
-        ctx.clearRect(0, 0, FIELD_SIZE, FIELD_SIZE);
-
-        // field border glow
-        ctx.save();
-        ctx.shadowBlur = 24;
-        ctx.shadowColor = 'rgba(0,224,184,0.25)';
-        ctx.strokeStyle = 'rgba(255,255,255,0.08)';
-        ctx.lineWidth = 2;
-        ctx.strokeRect(1, 1, FIELD_SIZE - 2, FIELD_SIZE - 2);
-        ctx.restore();
-
-        drawNet();
-
-        // paddles with contrasting colors
-        ctx.fillStyle = '#e7eef7'; // player: light
-        ctx.fillRect(player.x, player.y, PADDLE_WIDTH, PADDLE_HEIGHT);
-        ctx.fillStyle = '#29a3ff'; // AI: blue
-        ctx.fillRect(ai.x, ai.y, PADDLE_WIDTH, PADDLE_HEIGHT);
-
-        // trail and ball
-        drawTrail();
-        if (showBall) {
-            ctx.fillStyle = '#00e0b8';
-            ctx.fillRect(ball.x, ball.y, BALL_SIZE, BALL_SIZE);
-        }
-        // particles on top
-        drawParticles();
-    }
-
-    function update() {
-        if (isPlaying) {
-            updatePlayer();
-            updateAI();
-            updateBall();
-        }
-        updateParticles();
-        updateTrail();
-    }
-
-    function loop() {
-        update();
-        draw();
-        requestAnimationFrame(loop);
-    }
-
-    // Initialize
-    function init() {
-        // Pre-fill player name from localStorage
+      winningScoreInput.addEventListener("change", () => {
         try {
-            const saved = localStorage.getItem('neopong:playerName');
-            if (saved) playerNameInput.value = saved;
-            const savedTarget = localStorage.getItem('neopong:targetScore');
-            if (savedTarget && winningScoreInput) winningScoreInput.value = savedTarget;
+          localStorage.setItem(
+            "neopong:targetScore",
+            winningScoreInput.value.trim()
+          );
         } catch (_) {}
-
-        // Persist name and winning score when changed
-        playerNameInput.addEventListener('change', () => {
-            try { localStorage.setItem('neopong:playerName', playerNameInput.value.trim()); } catch (_) {}
-        });
-        if (winningScoreInput) {
-            winningScoreInput.addEventListener('change', () => {
-                try { localStorage.setItem('neopong:targetScore', winningScoreInput.value.trim()); } catch (_) {}
-            });
-        }
-
-        loop();
+      });
     }
 
-    init();
+    // Add theme toggle event listener
+    themeToggle.addEventListener("click", toggleTheme);
+
+    loop();
+  }
+
+  init();
 })();
-
-

--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
     <div class="app">
         <header class="header">
             <h1 class="title">NeoPong</h1>
+            <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark/light mode">
+                <svg id="themeIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                </svg>
+                <span id="themeText">Dark</span>
+            </button>
         </header>
 
         <main class="main">

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,29 @@
 :root {
+    /* Dark theme (default) */
     --bg: #0b0e13;
     --panel: #121722;
     --text: #e7eef7;
     --muted: #8aa0b8;
     --accent: #00e0b8;
     --accent-2: #29a3ff;
+    --canvas-bg: linear-gradient(180deg, #0f1a28 0%, #0b111a 100%);
+    --menu-bg: linear-gradient(180deg, rgba(11,14,19,0.75), rgba(11,14,19,0.85));
+    --input-bg: #0e1420;
+    --scoreboard-bg: rgba(6,10,16,0.75);
+}
+
+/* Light theme */
+[data-theme="light"] {
+    --bg: #f8fafc;
+    --panel: #ffffff;
+    --text: #1e293b;
+    --muted: #64748b;
+    --accent: #00e0b8;
+    --accent-2: #29a3ff;
+    --canvas-bg: linear-gradient(180deg, #e2e8f0 0%, #cbd5e1 100%);
+    --menu-bg: linear-gradient(180deg, rgba(248,250,252,0.75), rgba(248,250,252,0.85));
+    --input-bg: #f1f5f9;
+    --scoreboard-bg: rgba(255,255,255,0.75);
 }
 
 * { box-sizing: border-box; }
@@ -16,6 +35,11 @@ body {
     font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
     color: var(--text);
     background: radial-gradient(1200px 1200px at 80% -10%, #10233a 0%, var(--bg) 50%);
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+[data-theme="light"] body {
+    background: radial-gradient(1200px 1200px at 80% -10%, #e2e8f0 0%, var(--bg) 50%);
 }
 
 .app {
@@ -26,11 +50,44 @@ body {
 
 .header {
     padding: 16px 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 .title {
     margin: 0;
     font-weight: 800;
     letter-spacing: 1px;
+}
+
+/* Theme toggle button */
+.theme-toggle {
+    background: var(--panel);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 8px;
+    padding: 8px 12px;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+[data-theme="light"] .theme-toggle {
+    border: 1px solid rgba(0,0,0,0.1);
+}
+
+.theme-toggle:hover {
+    background: var(--accent);
+    color: #03121a;
+    transform: translateY(-1px);
+}
+
+.theme-toggle:active {
+    transform: translateY(0);
 }
 
 .main {
@@ -52,8 +109,13 @@ canvas#gameCanvas {
     width: 100%;
     height: 100%;
     display: block;
-    background: linear-gradient(180deg, #0f1a28 0%, #0b111a 100%);
+    background: var(--canvas-bg);
     outline: 1px solid rgba(255,255,255,0.06);
+    transition: background 0.3s ease;
+}
+
+[data-theme="light"] canvas#gameCanvas {
+    outline: 1px solid rgba(0,0,0,0.1);
 }
 
 /* Goal flash overlay */
@@ -88,7 +150,7 @@ canvas#gameCanvas {
     font-size: 72px;
     font-weight: 900;
     letter-spacing: 1px;
-    color: #e7eef7;
+    color: var(--text);
     text-shadow: 0 6px 32px rgba(0, 224, 184, 0.25);
     opacity: 0;
     transform: scale(0.85);
@@ -104,7 +166,8 @@ canvas#gameCanvas {
     inset: 0;
     display: grid;
     place-items: center;
-    background: linear-gradient(180deg, rgba(11,14,19,0.75), rgba(11,14,19,0.85));
+    background: var(--menu-bg);
+    transition: background 0.3s ease;
 }
 
 .menu-card {
@@ -115,6 +178,12 @@ canvas#gameCanvas {
     border-radius: 14px;
     padding: 24px;
     box-shadow: 0 8px 28px rgba(0,0,0,0.45);
+    transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+[data-theme="light"] .menu-card {
+    border: 1px solid rgba(0,0,0,0.1);
+    box-shadow: 0 8px 28px rgba(0,0,0,0.15);
 }
 
 .menu-card h2 {
@@ -138,10 +207,18 @@ canvas#gameCanvas {
     padding: 10px 12px;
     border-radius: 10px;
     border: 1px solid rgba(255,255,255,0.08);
-    background: #0e1420;
+    background: var(--input-bg);
     color: var(--text);
+    transition: background 0.3s ease, border-color 0.3s ease;
 }
+
+[data-theme="light"] .menu-input {
+    border: 1px solid rgba(0,0,0,0.1);
+}
+
 .menu-input::placeholder { color: #6b7b90; }
+
+[data-theme="light"] .menu-input::placeholder { color: #94a3b8; }
 
 .menu-button {
     margin-top: 14px;
@@ -172,9 +249,14 @@ canvas#gameCanvas {
     position: sticky;
     bottom: 0;
     width: 100%;
-    background: rgba(6,10,16,0.75);
+    background: var(--scoreboard-bg);
     border-top: 1px solid rgba(255,255,255,0.06);
     backdrop-filter: blur(8px);
+    transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+[data-theme="light"] .scoreboard {
+    border-top: 1px solid rgba(0,0,0,0.1);
 }
 .scoreboard-inner {
     max-width: 960px;


### PR DESCRIPTION
- Add theme toggle button in header with SVG icons
- Implement CSS variables for dark and light themes
- Make all game elements (paddles, ball, net, particles) theme-aware
- Add localStorage persistence for theme preference
- Update SPEC.md to include theme toggle requirements
- Ensure optimal readability in both themes